### PR TITLE
Auto-strip <think> tags for Minimax models

### DIFF
--- a/src/app/api/nvidia/route.ts
+++ b/src/app/api/nvidia/route.ts
@@ -72,6 +72,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(data, { status: response.status });
     }
 
+    if (response.ok && data.choices?.[0]?.message?.content) {
+      const isMinimax = model.toLowerCase().includes("minimax-m2");
+
+      if (isMinimax) {
+        let content = data.choices[0].message.content;
+        // Strip <think>...</think> tags and everything inside them
+        // Use a non-greedy regex to match correctly if multiple tags exist
+        content = content.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+        data.choices[0].message.content = content;
+        console.log(`Stripped <think> tags for model: ${model}`);
+      }
+    }
+
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error("Nvidia proxy error:", error);


### PR DESCRIPTION
Automatic <think> Tag Stripping:

This pull request adds logic to the `POST` handler in `src/app/api/nvidia/route.ts` to clean up responses from the Minimax M2 model by removing `<think>...</think>` tags from the returned content. This ensures that unnecessary tags are stripped from the output before it is sent to the client.

**Response formatting improvements:**

* Added code to detect if the model is Minimax M2 and, if so, remove all `<think>...</think>` tags (and their contents) from `data.choices[0].message.content` using a non-greedy regex before returning the response.