### PR TITLE
feat: add LiteLLM as built-in AI gateway provider

### DIFF
--- a/src/app/lib/translation/registry.ts
+++ b/src/app/lib/translation/registry.ts
@@ -713,6 +713,17 @@ export const PROVIDERS = {
       { label: "GPT-5.4 Nano", value: "gpt-5.4-nano", thinking: true },
     ],
   },
+  litellm: {
+    kind: "openai-compat",
+    category: "aggregator",
+    label: "LiteLLM",
+    endpoint: "http://localhost:4000/v1/chat/completions",
+    defaultModel: "",
+    defaultTemperature: 0.7,
+    docs: "https://docs.litellm.ai/docs/",
+    allowCustomUrl: true,
+    models: [],
+  },
   llm: {
     kind: "custom",
     category: "aggregator",


### PR DESCRIPTION


## Summary

Add [LiteLLM](https://github.com/BerriAI/litellm) as a built-in translation provider in the Aggregators & Self-hosted category, giving users access to 100+ LLM providers through a single OpenAI-compatible proxy.

## Changes

- `src/app/lib/translation/registry.ts` - Add `litellm` entry to `PROVIDERS` object as `openai-compat` aggregator

1 file, 11 additions. The entry auto-registers in the UI list, default configs, and dispatch table via the existing derived-view pattern.

## Tests

E2E against a live LiteLLM proxy (Azure AI Foundry Anthropic backend):
```
/v1/models:        ['claude-sonnet-4-6']
Chat completion:   Response: OK | Model: claude-sonnet-4-6 | PASS
```

TypeScript typecheck (`tsc --noEmit`) passes clean.

## Notes

- Purely additive. No existing providers modified.
- `allowCustomUrl: true` so users can point at any proxy address.
- Empty `models` array since available models depend on the user's proxy configuration.
- `defaultModel: ""` since no default can be assumed for a user-configured gateway.
