### PR TITLE
feat: add Atlas Cloud translation provider

### DIFF
--- a/src/app/lib/translation/registry.ts
+++ b/src/app/lib/translation/registry.ts
@@ -694,6 +694,24 @@ export const PROVIDERS = {
       { label: "MiniMax M3", value: "minimax/minimax-m3", thinking: true },
     ],
   },
+  atlascloud: {
+    kind: "openai-compat",
+    category: "aggregator",
+    label: "Atlas Cloud",
+    endpoint: "https://api.atlascloud.ai/v1/chat/completions",
+    defaultModel: "qwen/qwen3.8-max",
+    defaultTemperature: 0.7,
+    docs: "https://www.atlascloud.ai/docs",
+    apiKeyUrl: "https://www.atlascloud.ai/console/api-keys",
+    // Atlas Cloud exposes a shared OpenAI-compatible endpoint for its hosted
+    // text models. Keep thinking controls hidden because support and request
+    // shape vary by the selected upstream model.
+    models: [
+      { label: "Qwen3.8 Max", value: "qwen/qwen3.8-max" },
+      { label: "DeepSeek V4 Flash", value: "deepseek-ai/deepseek-v4-flash" },
+      { label: "GLM-5.2", value: "zai-org/glm-5.2" },
+    ],
+  },
   groq: {
     kind: "openai-compat",
     category: "aggregator",

--- a/src/app/lib/translation/services/index.ts
+++ b/src/app/lib/translation/services/index.ts
@@ -15,7 +15,7 @@ export const translationServices: Record<TranslationMethod, TranslationService> 
   qwenMt: traditional.qwenMt,
   translategemma: traditional.translategemma,
 
-  // LLM APIs — 12 OpenAI-compatible services auto-registered from OPENAI_COMPAT_PROVIDERS
+  // LLM APIs — OpenAI-compatible services auto-registered from OPENAI_COMPAT_PROVIDERS
   ...llm.openAICompatServices,
 
   // LLM APIs — special-case providers that don't fit the OpenAI-compatible shape


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class OpenAI-compatible translation provider
- provide the official API endpoint, docs, API-key link, and curated text models
- use the existing provider registry so UI configuration and runtime dispatch stay in sync

## Verification

- live Atlas Cloud Chat Completions request with `qwen/qwen3.8-max`: HTTP 200, non-empty translation
- browser CORS preflight: origin, POST, authorization, and content-type accepted
- `yarn lint` (0 errors; one pre-existing warning in `src/app/components/projects.tsx`)
- `yarn tsc --noEmit`
- `yarn build`

Signed-off-by: binyangzhu000-sudo <224954946+binyangzhu000-sudo@users.noreply.github.com>